### PR TITLE
refactor: remove the requirement for vpoly to take number of vars on instantiation

### DIFF
--- a/iops/sum_check/src/padded_sumcheck.rs
+++ b/iops/sum_check/src/padded_sumcheck.rs
@@ -155,9 +155,10 @@ mod tests {
     #[test]
     fn test_v_poly_padded_sumcheck() {
         // g(a, b, c) = f(a, b, c) * f(a, b, c)
-        let poly = VPoly::new(vec![f_abc(), f_abc()], 2, 3, Rc::new(prod_combined_fn));
+        let poly = VPoly::new(vec![f_abc(), f_abc()], 2, Rc::new(prod_combined_fn));
         // f(a, b, c) = 2ab + 3bc
         // f(1, 2, 3) = 2(1)(2) + 3(2)(3) = 4 + 18 = 22
+        assert_eq!(poly.num_vars(), 3);
         assert_eq!(
             poly.eval(&to_fields(vec![1, 2, 3])),
             Fields::Extension(E::from_canonical_u64(484))

--- a/poly/src/utils.rs
+++ b/poly/src/utils.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use p3_field::{ExtensionField, Field};
 
-use crate::{Fields, MultilinearExtension, mle::MultilinearPoly, vpoly::VPoly};
+use crate::{Fields, mle::MultilinearPoly, vpoly::VPoly};
 
 /// Evaluate a univariate polynomial in evaluation form
 pub fn barycentric_evaluation<F: Field, E: ExtensionField<F>>(
@@ -39,11 +39,9 @@ pub fn product_poly<F: Field, E: ExtensionField<F>>(
     mles: Vec<MultilinearPoly<F, E>>,
 ) -> VPoly<F, E> {
     let max_degree = mles.len();
-    let num_vars = mles[0].num_vars();
     VPoly::new(
         mles,
         max_degree,
-        num_vars,
         Rc::new(|values: &[Fields<F, E>]| values.iter().cloned().product()),
     )
 }

--- a/poly/src/vpoly.rs
+++ b/poly/src/vpoly.rs
@@ -39,10 +39,10 @@ impl<F: Field, E: ExtensionField<F>> VPoly<F, E> {
     pub fn new(
         mles: Vec<MultilinearPoly<F, E>>,
         max_degree: usize,
-        num_vars: usize,
         combine_fn: CombineFn<F, E>,
     ) -> Self {
         // assert all MLEs have the same number of variables
+        let num_vars = mles[0].num_vars();
         assert!(
             mles.iter().all(|mle| mle.num_vars() == num_vars),
             "MLEs must have the same number of variables"

--- a/poly/src/vpoly.rs
+++ b/poly/src/vpoly.rs
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn test_eval_1() {
         let mles = vec![f_abc(), f_abc(), f_abc()];
-        let vpoly = VPoly::new(mles, 2, 3, Rc::new(combined_fn_1)); // combination => 2(a * b) + c
+        let vpoly = VPoly::new(mles, 2, Rc::new(combined_fn_1)); // combination => 2(a * b) + c
         let points = vec![
             Fields::Base(F::from_canonical_u64(1)),
             Fields::Base(F::from_canonical_u64(2)),
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     fn test_sum_over_boolean_hypercube() {
         let mles = vec![f_abc(), f_abc(), f_abc()];
-        let vpoly = VPoly::new(mles, 2, 3, Rc::new(combined_fn_1)); // combination => 2(a * b) + c
+        let vpoly = VPoly::new(mles, 2, Rc::new(combined_fn_1)); // combination => 2(a * b) + c
         assert_eq!(
             vpoly.sum_over_hypercube(),
             Fields::Extension(E::from_canonical_u64(86))


### PR DESCRIPTION
we just ensure all polynomials making up the vpoly have the same number of variables, then use one of the var counts. 